### PR TITLE
Fix issue #100: get_val with HAVE_MPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ mpb/mpbi_mpi
 src/mpbi_mpi.h
 mpb/mu.c
 
+# local editor settings
+.vscode
+
 # test output:
 check-epsilon.h5
 check-mu.h5


### PR DESCRIPTION
Hi Steven,

I finally found sufficient incentive to attempt solving https://github.com/NanoComp/mpb/issues/100, i.e. making real-space interpolation work with MPI. 
I pretty much went about it in the way we discussed there (after finally understanding, I think, the transposition of *x*/*y* indices that you mentioned).

I've compiled this with and without MPI and verified that the interpolation produces good agreement for a simple 3D test case (see below) run with `mpb` vs. `mpb-mpi`:

| Value type | `mpb` (res=32) | `mpb-mpi` (res=32) | `mpb` (res=64) | `mpb-mpi` (res=64) |
| :-- | --: | --: | --: | --: |
| **H**-norm      | 0.78812 | 0.79027 | 0.83725 | 0.83490 |
| **H**-energy | 0.65716 | 0.66058 | 0.71445 | 0.71049 |
| **D**-norm    | 6.40814 | 6.40644 | 6.47873 | 6.48145 |
| **D**-energy | 6.70220 | 6.69825 | 6.81435 | 6.82025 |

evaluated at an arbitrary point. The results for `mpb-mpi` remain unchanged (up to tiny convergence variations) when run with different number processes.

<details>
<summary>3D test example (click to expand)</summary>

```scm
(set! resolution 64)
(set! num-bands 3)
(set! output-epsilon (lambda () (print "skipping output-epsilon\n")))

; define a simple geometry with inversion
(set! geometry-lattice (make lattice (size 1 1 1) 
                                     (basis1 1 0 0) (basis2 0 1 0) (basis3 0 0 1)))
(set! geometry (list (make sphere
                        (center 0 0 0) (radius 0.25) 
                        (material (make dielectric (epsilon 13) )))))
; set a k-point
(set! k-points (list (vector3 0.3532 0.1512 0.175)))


(run) ; run the calculation

; compute some interpolating values at an arbitrary real-space point
(define r (vector3 0.0 0.12 -0.22))
(define band-idx 3)

(print "\n\n")
(get-hfield band-idx)
(print "|H|:      " (vector3-norm (get-field-point r)) "\n")
(compute-field-energy)
(print "H-energy: " (get-energy-point r) "\n")

(get-dfield band-idx)
(print "|D|:      " (vector3-norm (get-field-point r)) "\n")
(compute-field-energy)
(print "D-energy: " (get-energy-point r) "\n")
```

</details>

Does this seem like a correct implementation? One concern I have is I didn't really think about the case of `HAVE_MPI` and *no* `SCALAR_COMPLEX`: would that need additional special-casing?

I also snuck in a tiny addition to `.gitignore` for working in VSCode (can be dropped, of course).