### PR TITLE
Flush stdout before initialization of epsilon

### DIFF
--- a/src/util/mpi_utils.c
+++ b/src/util/mpi_utils.c
@@ -144,6 +144,7 @@ void mpi_one_printf(const char *template, ...)
          vprintf(template, ap);
        }
        va_end(ap);
+       fflush(stdout);
      }
 }
 
@@ -151,10 +152,11 @@ void mpi_one_printf(const char *template, ...)
 void mpi_one_fprintf(FILE *f, const char *template, ...)
 {
      if (mpi_is_master()) {
-	  va_list ap;
-	  va_start(ap, template);
-	  vfprintf(f, template, ap);
-	  va_end(ap);
+       va_list ap;
+       va_start(ap, template);
+       vfprintf(f, template, ap);
+       va_end(ap);
+       fflush(f);
      }
 }
 


### PR DESCRIPTION
When the initialization of epsilon is very time-consuming (as in e.g. #117), the printout of "... Initializing epsilon function" often never happens until _after_ the initialization is complete; instead the printout just locks up at a random point beforehand (I guess, because of stream buffering).

This PR just adds a call to `fflush(stdout)` as a very minor quality of life improvement: so that it is hopefully clearer what is happening under the hood while a user waits.

I tested it locally for the serial implementation, where it works as intended.