### PR TITLE
Avoid default linmin verbosity (follow-up after #119)

### DIFF
--- a/src/matrices/linmin.c
+++ b/src/matrices/linmin.c
@@ -94,12 +94,12 @@ double linmin(double *converged_f, double *converged_df,
 	  }
 
 	  if (*task != 'C') {  /* not converged; warning or error */
-	       if ((verbose || mpb_verbosity >= 2 || *task == 'E')  && mpb_verbosity >= 2)
+	       if ((verbose || mpb_verbosity >= 3 || *task == 'E')  && mpb_verbosity >= 3)
 		    mpi_one_fprintf(stderr, "linmin: %s\n", task);
 	       CHECK(*task != 'E', "linmin failure");
 	  }
 
-	  if (verbose || mpb_verbosity >= 2)
+	  if (verbose || mpb_verbosity >= 3)
 	       mpi_one_printf("    linmin: converged after %d iterations.\n",
 			      iters);
 


### PR DESCRIPTION
I went ahead and just made the fix I proposed in https://github.com/NanoComp/mpb/pull/119#issuecomment-696341341