### PR TITLE
Slight sanity improvement to interface detection in `mean_epsilon_func`

### DIFF
--- a/mpb/epsilon.c
+++ b/mpb/epsilon.c
@@ -316,6 +316,18 @@ static int mean_epsilon_func(symmetric_matrix *meps,
 	  fill = 1 - box_overlap_with_object(pixel, *o2, tol, 100/tol);
      }
 
+    /* a neighbor point may have zero measure in the voxel (e.g. material terminating
+       on a voxel corner); just treat such "boundary points" as homogeneous */
+     if (fabs(fill) < tol) {          /* mat1 fills voxel (meps & meps_inv already set) */
+        n[0] = n[1] = n[2] = 0;
+        return 1;
+     }
+     else if (fabs(1 - fill) < tol) { /* mat2 fills voxel */
+        material_epsilon(mat2, meps, meps_inv);
+        n[0] = n[1] = n[2] = 0;
+        return 1;
+     }
+
      {
 	  symmetric_matrix eps2, epsinv2;
 	  symmetric_matrix eps1, delta;


### PR DESCRIPTION
While working on #127, I found that `mean_epsilon_func` occasionally identified too many interface points, corresponding to voxels where the `fill` value of one of the materials is zero. I figured the most consistent thing to do would be to just treat these situations as homogeneous, and moreover to set a threshold at the tolerance `tol` used to compute the filling fraction in the first place.