### PR TITLE
change default verbosity to 1

### DIFF
--- a/src/util/verbosity.c
+++ b/src/util/verbosity.c
@@ -19,4 +19,4 @@
 #include "verbosity.h"
 
 /* The global verbosity flag. See verbosity.h */
-int mpb_verbosity = 2;
+int mpb_verbosity = 1;


### PR DESCRIPTION
This is a resolution to @tchr's [comment](https://github.com/NanoComp/mpb/pull/125#issuecomment-722610360) in #125 proposed by @RobinD42:

> As for the verbosity issue, a super simple change that should keep both Steven and Thomas happy would be to change the `mpb_verbosity` variable's default value to 1 in mpb's `src/util/verbosity.c`. Then it will start out as 1 when mpb is used on its own as Thomas seems to be doing, but it will still be set to 2 when it is loaded into the Python Verbosity class from meep, which IIRC is what Steven wanted.