### PR TITLE
Unbreak `examples/check.ctl` under MPI

### DIFF
--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -586,15 +586,15 @@ $W$ and $w$ should be supplied as `matrix3x3` and `vector3` variables in the bas
 
 Given the character tables associated with the little groups of a considered photonic crystal, this functionality can e.g. be used to infer which irreducible representation (irrep) a given band (or band grouping) transforms as across the Brillouin zone.
 
-**`(compute-symmetry which_band W w)`**
+**`(compute-symmetry which-band W w)`**
 Compute the $(\mathbf{H}|g\mathbf{B})$ character for `which-band` under a symmetry operation with rotation `W` and translation `w`, returning a complex number.
 
 **`(compute-symmetries W w)`**
 Equivalent to `compute-symmetry`, but returns characters for *all* computed bands, returning a list of complex numbers.
 
-**`(transformed_overlap W w)`**
+**`(transformed-overlap W w)`**
 Sets **F**′ to `curfield` (must be either a **D**- or **B**-field) and computes the associated character under the symmetry operation specified by `W` and `w`, returning a complex number.
-Usually, it will be more convenient to call `compute-symmetry` (which wraps `transformed_overlap` with an initialization of `curfield` via `get-bfield`).
+Usually, it will be more convenient to call `compute-symmetry` (which wraps `transformed-overlap` with an initialization of `curfield` via `get-bfield`).
 
 Field Manipulation
 ------------------

--- a/examples/check.ctl
+++ b/examples/check.ctl
@@ -303,6 +303,9 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(if (not (using-mpi?)) ; currently do not support transformed-overlap with MPI
+(begin
+
 (print
  "**************************************************************************\n"
  " Test case: symmetry transformed overlaps & inversion/mirror eigenvalues.\n"
@@ -341,6 +344,10 @@
 (define symeigs-zodd (compute-symmetries mz w))
 (check-almost-equal (map real-part symeigs-zodd) '(-1 -1 -1 -1 -1 -1))
 (check-almost-equal (map imag-part symeigs-zodd) '( 0  0  0  0  0  0))
+
+
+) ; begin
+) ; if (not (using-mpi?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I realized that the changes from #134 broke `make check` when compiled with MPI, because the symmetry-eigenvalue tests would try to run but fail because the code throws a `transformed_overlap(..) is not yet implemented for MPI` error.

This just disables that check if `(using-mpi?)` is true.