### PR TITLE
fix #144 (`make-uniform-array` -> `make-typed-array`)

### DIFF
--- a/mpb/mpb.scm.in
+++ b/mpb/mpb.scm.in
@@ -78,9 +78,9 @@
     (lambda (object)
       (let ((sz (object-property-value object 'size))
 	    (i (object-property-value object 'matgrid-init)))
-	(let ((g (apply make-uniform-array 
-			(cons 0.333 (map inexact->exact (vector->list sz))))))
-	  (array-index-map! g (lambda (x y z) 
+	(let ((g (apply make-typed-array
+			(cons 'f64 (cons *unspecified* (map inexact->exact (vector->list sz)))))))
+	  (array-index-map! g (lambda (x y z)
 				(i (- (/ x (vector3-x sz)) 0.5)
 				   (- (/ y (vector3-y sz)) 0.5)
 				   (- (/ z (vector3-z sz)) 0.5))))


### PR DESCRIPTION
Just following the suggestion in #144.
I understood the `0.333` fill-value as being arbitrary (overwritten immediately afterwards), so I replaced it with `*unspecified*` to avoid filling it unnecessarily. 