### PR TITLE
Prepare for 1.12 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## MPB 1.11.1
 
+4/3/25
+
+* Add support for anisotropic subpixel smoothing (#127).
+
+* Add support for computing mode-overlap integral under symmetry operation (#134).
+
+* Disable subpixel smoothing for mesh size of one (#150).
+
+* Various minor fixes and additional documentation (#138, #140, #141, #145, #149).
+
 10/23/20
 
 * Fix compilation error on MacOS for `mpb/fields.c`.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([mpb],[1.11.1])
+AC_INIT([mpb],[1.12.0])
 AC_CONFIG_SRCDIR([src/matrices/matrices.c])
 AC_CONFIG_HEADERS([config.h src/mpbconf.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -8,7 +8,7 @@ AM_MAINTAINER_MODE
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.)
-SHARED_VERSION_INFO="5:1:4" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="6:0:0" # CURRENT:REVISION:AGE
 
 VERSION_MAJOR=`echo $PACKAGE_VERSION | cut -d. -f1`
 VERSION_MINOR=`echo $PACKAGE_VERSION | cut -d. -f2`


### PR DESCRIPTION
The next tarball release is tentatively scheduled for Thursday April 3, 2025.