### PR TITLE
Add guard in line minimization of conjugate gradient to check for convergence via zero B-norm

### DIFF
--- a/src/matrices/eigensolver.c
+++ b/src/matrices/eigensolver.c
@@ -577,6 +577,7 @@ void eigensolver_lagrange(evectmatrix Y, real *eigenvals,
 
 	       d_norm = sqrt(SCALAR_RE(evectmatrix_traceXtY(BD,D)) / Y.p);
 	       mpi_assert_equal(d_norm);
+               if (d_norm == 0) break; /* D has zero B-norm; converged */
 
 	       /* dE = 2 * tr Gt D.  (Use prev_G instead of G so that
 		  it works even when we are using Polak-Ribiere.) */
@@ -650,6 +651,7 @@ void eigensolver_lagrange(evectmatrix Y, real *eigenvals,
 
 	       d_scale = sqrt(SCALAR_RE(evectmatrix_traceXtY(BD, D)) / Y.p);
 	       mpi_assert_equal(d_scale);
+               if (d_scale == 0) break; /* D has zero B-norm; converged */
 	       blasglue_rscal(Y.p * Y.n, 1/d_scale, D.data, 1);
 	       if (B) blasglue_rscal(Y.p * Y.n, 1/d_scale, BD.data, 1);
 


### PR DESCRIPTION
In single-precision floating point, the conjugate gradient search direction `D` can have a B-norm (`trace(D^t B D)`) that evaluates to exactly zero due to float's limited precision (~7 significant digits). This causes `d_scale = sqrt(trace(D^t B D) / p) / p) = 0` and then `1/d_scale = inf`, which propagates NaN through all subsequent matrix operations — ultimately reaching `trace_func` where `theta = NaN`, making `cos(NaN) = NaN` and `sin(NaN) = NaN`, and triggering the [singularity check failure](https://github.com/NanoComp/mpb/blob/16991f378a646c3ec181fe1e7be71b2c38be7b74/src/matrices/eigensolver.c#L140).

**Fix:** Add a guard in both the exact and approximate line minimization paths in `eigensolver.c` to `break` out of the iteration loop when `d_scale == 0` (or `d_norm == 0`). A zero B-norm for the search direction means the gradient has effectively vanished, so the eigensolver has converged.