### PR TITLE
fix compiler warnings about function prototypes etc

### DIFF
--- a/mpb/fields.c
+++ b/mpb/fields.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 #include <ctype.h>
 #include <stddef.h>

--- a/mpb/material_grid_opt.c
+++ b/mpb/material_grid_opt.c
@@ -63,7 +63,7 @@ static double mindiff_func(int n, const double *u, double *grad, void *data)
     solve_kpoint(d->k);
     gap = (f2 = freqs.items[d->b-1]);
     if (grad) {
-        material_grids_addgradient(work, 1.0, d->b, 
+        material_grids_addgradient(work, 1.0, d->b,
                                    d->grids, d->ngrids);
     }
 
@@ -72,15 +72,15 @@ static double mindiff_func(int n, const double *u, double *grad, void *data)
     solve_kpoint(d->k);
     gap -= (f1 = freqs.items[d->b-1]);
     if (grad) {
-        material_grids_addgradient(work, -1.0, d->b, 
+        material_grids_addgradient(work, -1.0, d->b,
                                    d->grids, d->ngrids);
     }
 
     if (grad) /* gradient w.r.t. epsilon needs to be summed over processes */
-        mpi_allreduce(work, grad, n, double, MPI_DOUBLE, 
+        mpi_allreduce(work, grad, n, double, MPI_DOUBLE,
                       MPI_SUM, mpb_comm);
 
-     mpi_one_printf("material-grid-mindiff:, %d, %g, %g, %0.15g\n", 
+     mpi_one_printf("material-grid-mindiff:, %d, %g, %g, %0.15g\n",
                     d->iter, f1, f2, gap);
 
      return gap;
@@ -191,7 +191,7 @@ static double band_constraint(int n, const double *u, double *grad, void *data)
      if (grad) memset(work, 0, sizeof(double) * (n-2));
      if (kind == BAND1_CONSTRAINT) {
 	  if (grad) {
-	       material_grids_addgradient(work, 1.0, d->b1, 
+	       material_grids_addgradient(work, 1.0, d->b1,
 					  d->grids, d->ngrids);
 	       grad[n-1] = -1;
 	       grad[n-2] = 0;
@@ -200,7 +200,7 @@ static double band_constraint(int n, const double *u, double *grad, void *data)
      }
      else {
 	  if (grad) {
-	       material_grids_addgradient(work, -1.0, d->b2, 
+	       material_grids_addgradient(work, -1.0, d->b2,
 					  d->grids, d->ngrids);
 	       grad[n-1] = 0;
 	       grad[n-2] = 1;
@@ -208,7 +208,7 @@ static double band_constraint(int n, const double *u, double *grad, void *data)
 	  val = u[n-2] - (d->f2s[ik] = freqs.items[d->b2-1]);
      }
      if (grad) /* gradient w.r.t. epsilon needs to be summed over processes */
-	  mpi_allreduce(work, grad, n-2, double, MPI_DOUBLE, 
+	  mpi_allreduce(work, grad, n-2, double, MPI_DOUBLE,
 			MPI_SUM, mpb_comm);
 
      return val;
@@ -227,7 +227,7 @@ static double maxgap_func(int n, const double *u, double *grad, void *data)
      d->unsolved = 1;
 
      gap = (f2 - f1) * 2.0 / (f1 + f2);
-     
+
      if (grad) {
 	  memset(grad, 0, sizeof(double) * (n-2));
 	  grad[n-1] = 2.0 * ((f1 + f2) - (f1 - f2)) / ((f1+f2)*(f1+f2));
@@ -238,13 +238,13 @@ static double maxgap_func(int n, const double *u, double *grad, void *data)
 	  }
      }
 
-     mpi_one_printf("material-grid-%sgap:, %d, %g, %g, %0.15g\n", 
+     mpi_one_printf("material-grid-%sgap:, %d, %g, %g, %0.15g\n",
 		    d->do_min ? "min" : "max", d->iter, f1, f2, gap);
-     
+
      if (verbose) {
 	  char prefix[256];
 	  get_epsilon();
-	  snprintf(prefix, 256, "%sgap-%04d-", 
+	  snprintf(prefix, 256, "%sgap-%04d-",
 		   d->do_min ? "min" : "max", d->iter);
 	  output_field_to_file(-1, prefix);
      }
@@ -253,7 +253,7 @@ static double maxgap_func(int n, const double *u, double *grad, void *data)
 }
 
 static number material_grids_maxmin_gap(boolean do_min,
-					vector3_list kpoints, 
+					vector3_list kpoints,
 					integer band1, integer band2,
 					number func_tol, number eps_tol,
 					integer maxeval, number maxtime)
@@ -323,7 +323,7 @@ static number material_grids_maxmin_gap(boolean do_min,
      mma_verbose = kpoints.num_items*2;
      res = nlopt_minimize_constrained(
 	  NLOPT_LD_MMA, n, maxgap_func, &d,
-	  kpoints.num_items*2, band_constraint, 
+	  kpoints.num_items*2, band_constraint,
 	  cdata, sizeof(band_constraint_data),
 	  lb, ub, u, &func_min,
 	  -HUGE_VAL, func_tol,0, 0,u_tol, maxeval,maxtime);
@@ -352,7 +352,7 @@ static number material_grids_maxmin_gap(boolean do_min,
 
      func_min = (u[n-2] - u[n-1]) * 2.0 / (u[n-1] + u[n-2]);
      mpi_one_printf("material-grid-%sgap:, %d, %g, %g, %0.15g\n",
-                    d.do_min ? "min" : "max", d.iter+1, 
+                    d.do_min ? "min" : "max", d.iter+1,
 		    u[n-1], u[n-2], func_min);
      func_min = d.do_min ? func_min : -func_min;
 
@@ -364,7 +364,7 @@ static number material_grids_maxmin_gap(boolean do_min,
      return(do_min ? func_min : -func_min);
 }
 
-number material_grids_maxgap(vector3_list kpoints, 
+number material_grids_maxgap(vector3_list kpoints,
 			     integer band1, integer band2,
 			     number func_tol, number eps_tol,
 			     integer maxeval, number maxtime)
@@ -373,7 +373,7 @@ number material_grids_maxgap(vector3_list kpoints,
 				      func_tol, eps_tol, maxeval, maxtime);
 }
 
-number material_grids_mingap(vector3_list kpoints, 
+number material_grids_mingap(vector3_list kpoints,
 			     integer band1, integer band2,
 			     number func_tol, number eps_tol,
 			     integer maxeval, number maxtime)

--- a/mpb/mpb.c
+++ b/mpb/mpb.c
@@ -194,7 +194,7 @@ number mpi_max(number num)
 /**************************************************************************/
 /* expose some build info to guile */
 
-boolean has_hermitian_epsp()
+boolean has_hermitian_epsp(void)
 {
 #if WITH_HERMITIAN_EPSILON
     return 1;
@@ -203,7 +203,7 @@ boolean has_hermitian_epsp()
 #endif
 }
 
-boolean has_inversion_symp()
+boolean has_inversion_symp(void)
 {
 #if SCALAR_COMPLEX
     return 0;
@@ -869,7 +869,7 @@ number_list compute_yparities(void)
    group velocities, one for each band, in units of c. */
 number_list compute_group_velocity_component(vector3 d)
 {
-     number_list group_v;
+     number_list group_v = { 0, (number *) NULL };
      real *gv_scratch;
      real u[3];
      int i, ib;
@@ -951,7 +951,7 @@ number compute_1_group_velocity_component(vector3 d, integer b)
 {
      real u[3];
      int ib = b - 1;
-     real group_v, scratch;
+     real group_v = 0, scratch;
 
      curfield_reset();
 

--- a/mpb/mpb.h
+++ b/mpb/mpb.h
@@ -111,5 +111,7 @@ void material_grids_addgradient(double *v,
 /**************************************************************************/
 
 extern const char *parity_string(maxwell_data *d);
+boolean has_hermitian_epsp(void);
+boolean has_inversion_symp(void);
 
 #endif /* MPB_H */

--- a/mpb/transform.c
+++ b/mpb/transform.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 
 #include "config.h"
@@ -32,9 +33,9 @@
 
 
 
-/* If `curfield` is the real-space D-field (of band-index i), computes the overlap 
+/* If `curfield` is the real-space D-field (of band-index i), computes the overlap
  *       ∫ Eᵢ†(r){W|w}Dᵢ(r) dr  =  ∫ Eᵢ†(r)(WDᵢ)({W|w}⁻¹r) dr,
- * for a symmetry operation {W|w} with rotation W and translation w; each specified 
+ * for a symmetry operation {W|w} with rotation W and translation w; each specified
  * in the lattice basis. The vector fields Eᵢ and Dᵢ include Bloch phases.
  * If `curfield` is the real-space B-field, the overlap
  *       ∫ Hᵢ†(r){W|w}Bᵢ(r) dr  =  det(W) ∫ Hᵢ†(r)(WBᵢ)({W|w}⁻¹r) dr,
@@ -43,7 +44,7 @@
  * independent of whether the D- or B-field is used.
  * No other choices for `curfield` are allowed: to set `curfield` to the real-space
  * B- or D-field use the `get-bfield` and `get-dfield` Scheme functions or the
- * `get_bfield` and `get_dfield` in C functions.                   
+ * `get_bfield` and `get_dfield` in C functions.
  * Usually, it will be more convenient to use the wrapper `compute_symmetry(i, W, w)`
  * which defaults to the B-field (since μ = 1 usually) and takes a band-index `i`.
  */
@@ -70,7 +71,7 @@ cnumber transformed_overlap(matrix3x3 W, vector3 w)
          * counting the number of grid points correctly somehow: I think the root issue is
          * that we use the LOOP_XYZ macro, which has special handling for mbpi (i.e. only
          * "visits" the "inversion-reduced" part of the unitcell): but here, we actually
-         * really want to (or at least assume to) visit _all_ the points in the unitcell. 
+         * really want to (or at least assume to) visit _all_ the points in the unitcell.
          */
     #endif
     #ifdef HAVE_MPI
@@ -83,7 +84,7 @@ cnumber transformed_overlap(matrix3x3 W, vector3 w)
          * Long story short: disable it for now.
          */
     #endif
-    
+
     /* prepare before looping ... */
     n1 = mdata->nx; n2 = mdata->ny; n3 = mdata->nz;
 
@@ -128,7 +129,7 @@ cnumber transformed_overlap(matrix3x3 W, vector3 w)
         /* transformed coordinate pt = {W|w}⁻¹p = W⁻¹(p-w) since {W|w}⁻¹={W⁻¹|-W⁻¹w} */
         pt = matrix3x3_vector3_mult(invW, vector3_minus(p, w));
 
-        /* Bloch field value at transformed coordinate pt: interpolation is needed to 
+        /* Bloch field value at transformed coordinate pt: interpolation is needed to
          * ensure generality in the case of fractional translations.                  */
         get_bloch_field_point_(Ftemp, pt); /* assign `Ftemp` to field at `pt` (without eⁱᵏʳ factor) */
 
@@ -157,7 +158,7 @@ cnumber transformed_overlap(matrix3x3 W, vector3 w)
             F[1] = curfield[3*xyz_index+1];
             F[2] = curfield[3*xyz_index+2];
         }
-        
+
         /* inner product of F and Ft={W|w}F in Bloch form */
         CASSIGN_CONJ_MULT(integrand, F[0], Ft[0]);  /* add adjoint(F)*Ft to integrand */
         CACCUMULATE_SUM_CONJ_MULT(integrand, F[1], Ft[1]);


### PR DESCRIPTION
Fix #173 and some other compiler warnings about function prototypes, and one uninitialized-variable warning.

(Also a bunch of extraneous whitespace changes due to my editor deleting trailing whitespace … append `?w=1` to the diff to remove.  At some point we should run this repo through `clang-format` …)